### PR TITLE
Added support for changing the polled I2C address without changing it…

### DIFF
--- a/I2CSoilMoistureSensor.cpp
+++ b/I2CSoilMoistureSensor.cpp
@@ -49,7 +49,7 @@ I2CSoilMoistureSensor::I2CSoilMoistureSensor(uint8_t addr) : sensorAddress(addr)
 /*----------------------------------------------------------------------*
  * Initializes anything ... it does a reset.                            *
  * When used without parameter or parameter value is false then a       *
- *  waiting time of at least 3 seconds is expected to give the sensor   *
+ * waiting time of at least 1 second is expected to give the sensor     *
  * some time to boot up.                                                *
  * Alternatively use true as parameter and the method waits for a       *
  * second and returns after that.                                       *

--- a/I2CSoilMoistureSensor.cpp
+++ b/I2CSoilMoistureSensor.cpp
@@ -47,10 +47,18 @@ I2CSoilMoistureSensor::I2CSoilMoistureSensor(uint8_t addr) : sensorAddress(addr)
 }
   
 /*----------------------------------------------------------------------*
- * Initializes anything ... it does a reset only at the moment          *
+ * Initializes anything ... it does a reset.                            *
+ * When used without parameter or parameter value is false then a       *
+ *  waiting time of at least 3 seconds is expected to give the sensor   *
+ * some time to boot up.                                                *
+ * Alternatively use true as parameter and the method waits for a       *
+ * second and returns after that.                                       *
  *----------------------------------------------------------------------*/
-void I2CSoilMoistureSensor::begin() {
+void I2CSoilMoistureSensor::begin(bool wait) {
   resetSensor();
+  if (wait) {
+    delay(1000);
+  }
 }
 
 /*----------------------------------------------------------------------*
@@ -72,8 +80,7 @@ unsigned int I2CSoilMoistureSensor::getCapacitance() {
 bool I2CSoilMoistureSensor::setAddress(int addr, bool reset) {
   writeI2CRegister8bit(sensorAddress, SOILMOISTURESENSOR_SET_ADDRESS, addr);
   if (reset) {
-    resetSensor();
-    delay(1000);
+	begin(1);
   }
   sensorAddress=addr;
   return (readI2CRegister8bit(sensorAddress, SOILMOISTURESENSOR_GET_ADDRESS) == addr);
@@ -83,10 +90,9 @@ bool I2CSoilMoistureSensor::setAddress(int addr, bool reset) {
  * Change the address (1..127) this instance is trying to read from     *
  * and do a reset after to initialize.                                  *
  *----------------------------------------------------------------------*/
-void I2CSoilMoistureSensor::changeAddress(int addr) {
+void I2CSoilMoistureSensor::changeSensor(int addr, bool wait) {
   sensorAddress=addr;
-  resetSensor();
-  delay(1000);
+  begin(wait);
 }
 
 /*----------------------------------------------------------------------*

--- a/I2CSoilMoistureSensor.cpp
+++ b/I2CSoilMoistureSensor.cpp
@@ -80,6 +80,16 @@ bool I2CSoilMoistureSensor::setAddress(int addr, bool reset) {
 }
 
 /*----------------------------------------------------------------------*
+ * Change the address (1..127) this instance is trying to read from     *
+ * and do a reset after to initialize.                                  *
+ *----------------------------------------------------------------------*/
+void I2CSoilMoistureSensor::changeAddress(int addr) {
+  sensorAddress=addr;
+  resetSensor();
+  delay(1000);
+}
+
+/*----------------------------------------------------------------------*
  * Return current Address of the Sensor                                 *
  *----------------------------------------------------------------------*/
 uint8_t I2CSoilMoistureSensor::getAddress() {

--- a/I2CSoilMoistureSensor.h
+++ b/I2CSoilMoistureSensor.h
@@ -39,6 +39,7 @@ class I2CSoilMoistureSensor {
 		void begin();
         unsigned int getCapacitance();
         bool setAddress(int addr, bool reset);
+        void changeAddress(int addr);
         uint8_t getAddress();
         void startMeasureLight();
         unsigned int getLight(bool wait = false);

--- a/I2CSoilMoistureSensor.h
+++ b/I2CSoilMoistureSensor.h
@@ -36,10 +36,10 @@ class I2CSoilMoistureSensor {
     public:
         I2CSoilMoistureSensor(uint8_t addr = SOILMOISTURESENSOR_DEFAULT_ADDR);
 
-		void begin();
+		void begin(bool wait = false);
         unsigned int getCapacitance();
         bool setAddress(int addr, bool reset);
-        void changeAddress(int addr);
+        void changeSensor(int addr, bool wait = false);
         uint8_t getAddress();
         void startMeasureLight();
         unsigned int getLight(bool wait = false);

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ returns true if the new address is set successfully on sensor.
 ### getAddress()
 Return current Address of the Sensor
 
+### changeSensor(int addr, bool wait)
+Changes the address (1..127) of the sensor, this instance is trying to read from
+and do a reset after to initialize.
+The second parameter is optional and tells the method to wait for a second to allow
+the sensor to boot up.
+
 ### startMeasureLight()
 Starts the measurement for the Light sensor. Wait at least 3 seconds till you call method 
 getLight to get the Light value.                *

--- a/README.md
+++ b/README.md
@@ -13,8 +13,13 @@ More informations at: https://www.tindie.com/products/miceuz/i2c-soil-moisture-s
 Optionally set sensor I2C address if different from default
 
 
-### begin()
-Initializes anything ... it does a reset only at the moment
+### begin(bool wait)
+Initializes anything ... it does a reset.
+When used without parameter or parameter value is false then a
+waiting time of at least 1 second is expected to give the sensor
+some time to boot up.
+Alternatively use true as parameter and the method waits for a
+second and returns after that.
 
 ### getCapacitance()
 Return measured Soil Moisture Capacitance Moisture is somewhat linear. More moisture will 


### PR DESCRIPTION
… on the device

I needed to store more than one sensor objects in an array. Since initializing the array will use the default constructor on every object (and therefore the default hardware ID), there was no way to actually do this properly without this patch.
