### PR TITLE
corrected wrong reading on temperatures below zero

### DIFF
--- a/I2CSoilMoistureSensor.cpp
+++ b/I2CSoilMoistureSensor.cpp
@@ -195,29 +195,27 @@ void I2CSoilMoistureSensor::writeI2CRegister8bit(int addr, int reg, int value) {
 /*----------------------------------------------------------------------*
  * Helper method to read a 16 bit unsigned value from the given register*
  *----------------------------------------------------------------------*/
-unsigned int I2CSoilMoistureSensor::readI2CRegister16bitUnsigned(int addr, int reg) {
-  i2cBeginTransmission(addr);
-  i2cWrite(reg);
+uint16_t I2CSoilMoistureSensor::readI2CRegister16bitUnsigned(int addr, byte reg)
+{
+  uint16_t value;
+
+  i2cBeginTransmission((uint8_t)addr);
+  i2cWrite((uint8_t)reg);
   i2cEndTransmission();
   delay(20);
-  i2cRequestFrom(addr, 2);
-  unsigned int t = i2cRead() << 8;
-  t = t | i2cRead();
-  return t;
+  i2cRequestFrom((uint8_t)addr, (byte)2);
+  value = (i2cRead() << 8) | i2cRead();
+  i2cEndTransmission();
+
+  return value;
 }
 
 /*----------------------------------------------------------------------*
  * Helper method to read a 16 bit signed value from the given register*
  *----------------------------------------------------------------------*/
-int I2CSoilMoistureSensor::readI2CRegister16bitSigned(int addr, int reg) {
-  i2cBeginTransmission(addr);
-  i2cWrite(reg);
-  i2cEndTransmission();
-  delay(20);
-  i2cRequestFrom(addr, 2);
-  int t = i2cRead() << 8;
-  t = t | i2cRead();
-  return t;
+int16_t I2CSoilMoistureSensor::readI2CRegister16bitSigned(int addr, byte reg)
+{
+  return (int16_t)readI2CRegister16bitUnsigned(addr, reg);
 }
 
 /*----------------------------------------------------------------------*

--- a/I2CSoilMoistureSensor.h
+++ b/I2CSoilMoistureSensor.h
@@ -56,8 +56,8 @@ class I2CSoilMoistureSensor {
 
         void writeI2CRegister8bit(int addr, int value);
         void writeI2CRegister8bit(int addr, int reg, int value);
-        unsigned int readI2CRegister16bitUnsigned(int addr, int reg);
-        int readI2CRegister16bitSigned(int addr, int reg);
+        uint16_t readI2CRegister16bitUnsigned(int addr, byte reg);
+        int16_t readI2CRegister16bitSigned(int addr, byte reg);
         uint8_t readI2CRegister8bit(int addr, int reg);
 };
 


### PR DESCRIPTION
the library reportes wrong reading when temperatures where below zero...  ..i reported this some time ago, and i think it was fixed then, but in the current version it gives wrong readings on negative values once again:

example script output before my pull request:
Soil Moisture Capacitance: 376, Temperature: 14.20, Light: 19194
Soil Moisture Capacitance: 349, Temperature: 10.20, Light: 19046
Soil Moisture Capacitance: 348, Temperature: 7.90, Light: 19295
Soil Moisture Capacitance: 348, Temperature: 6.40, Light: 19519
Soil Moisture Capacitance: 383, Temperature: 4.80, Light: 18892
Soil Moisture Capacitance: 382, Temperature: 1.30, Light: 21959
Soil Moisture Capacitance: 376, Temperature: 6551.90, Light: 19143
Soil Moisture Capacitance: 376, Temperature: 6550.00, Light: 19155


and after my correction:
Soil Moisture Capacitance: 394, Temperature: 18.80, Light: 16303
Soil Moisture Capacitance: 368, Temperature: 15.60, Light: 25119
Soil Moisture Capacitance: 383, Temperature: 10.80, Light: 17365
Soil Moisture Capacitance: 398, Temperature: 6.30, Light: 16304
Soil Moisture Capacitance: 397, Temperature: 1.00, Light: 16199
Soil Moisture Capacitance: 397, Temperature: -2.90, Light: 16106
Soil Moisture Capacitance: 397, Temperature: -5.70, Light: 16009
Soil Moisture Capacitance: 397, Temperature: -7.80, Light: 16097
Soil Moisture Capacitance: 399, Temperature: -9.30, Light: 14732
Soil Moisture Capacitance: 397, Temperature: -10.70, Light: 16354

adopted the code from an bme280 library and it seems to work better with negative values...