### PR TITLE
Add a duplicate call for changing the address. This is required by th…

### DIFF
--- a/I2CSoilMoistureSensor.cpp
+++ b/I2CSoilMoistureSensor.cpp
@@ -79,6 +79,7 @@ unsigned int I2CSoilMoistureSensor::getCapacitance() {
  *----------------------------------------------------------------------*/
 bool I2CSoilMoistureSensor::setAddress(int addr, bool reset) {
   writeI2CRegister8bit(sensorAddress, SOILMOISTURESENSOR_SET_ADDRESS, addr);
+  writeI2CRegister8bit(sensorAddress, SOILMOISTURESENSOR_SET_ADDRESS, addr);
   if (reset) {
 	resetSensor();
     delay(1000);

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ More informations at: https://www.tindie.com/products/miceuz/i2c-soil-moisture-s
 
 ## Version History
 
+### v1.1.3
+-  updated the change address protocol to be compatible with firmware version 2.6 and later.
+
 ### v1.1.2
 -  changed/fixed handling of negative temperature values (thanks to @krikk)
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=I2CSoilMoistureSensor
-version=1.1.2
+version=1.1.3
 author=Ingo Fischer <ingo@fischer-ka.de>
 maintainer=Ingo Fischer <ingo@fischer-ka.de>
 sentence=Provide access to all functions of the I2C Soil Moisture Sensor from Catnip Electronics.


### PR DESCRIPTION
…e new sensor firmware version 2.6. This is to avoid a stry address change command that happens during hotplugging of the sensor