### PR TITLE
Added option to use "Full" Chirp

### DIFF
--- a/I2CSoilMoistureSensor.cpp
+++ b/I2CSoilMoistureSensor.cpp
@@ -7,7 +7,7 @@
  * https://github.com/Apollon77/I2CSoilMoistureSensor                   *
  *                                                                      *
  * MIT license                                                          *
- *----------------------------------------------------------------------*/ 
+ *----------------------------------------------------------------------*/
 
 #include "I2CSoilMoistureSensor.h"
 
@@ -38,7 +38,9 @@
 #define i2cWrite Wire.send
 #endif
 
-int readslow = 20
+int readSlowDelay = 20;
+int measureLightDelay = 3000;
+
 /*----------------------------------------------------------------------*
  * Constructor.                                                         *
  * Optionally set sensor I2C address if different from default          *
@@ -46,7 +48,7 @@ int readslow = 20
 I2CSoilMoistureSensor::I2CSoilMoistureSensor(uint8_t addr) : sensorAddress(addr) {
   // nothing to do ... Wire.begin needs to be put outside of class
 }
-  
+
 /*----------------------------------------------------------------------*
  * Initializes anything ... it does a reset.                            *
  * When used without parameter or parameter value is false then a       *
@@ -55,20 +57,21 @@ I2CSoilMoistureSensor::I2CSoilMoistureSensor(uint8_t addr) : sensorAddress(addr)
  * Alternatively use true as parameter and the method waits for a       *
  * second and returns after that.                                       *
  *----------------------------------------------------------------------*/
-void I2CSoilMoistureSensor::begin(bool wait, bool readslowbool) {
+void I2CSoilMoistureSensor::begin(bool wait, bool readSlowOption) {
   resetSensor();
   if (wait) {
     delay(1000);
   }
-  if (readslowbool) {
-    readslow = 1100;
+  if (readSlowOption) {
+    readSlowDelay = 1100;
+    measureLightDelay = 9000;
   }
 }
 
 /*----------------------------------------------------------------------*
  * Return measured Soil Moisture Capacitance                            *
  * Moisture is somewhat linear. More moisture will give you higher      *
- * reading. Normally all sensors give about 290 - 310 as value in free  * 
+ * reading. Normally all sensors give about 290 - 310 as value in free  *
  * air at 5V supply.                                                    *
  *----------------------------------------------------------------------*/
 unsigned int I2CSoilMoistureSensor::getCapacitance() {
@@ -133,7 +136,7 @@ void I2CSoilMoistureSensor::startMeasureLight() {
 unsigned int I2CSoilMoistureSensor::getLight(bool wait) {
   if (wait) {
     startMeasureLight();
-    delay(3000);
+    delay(measureLightDelay);
   }
   return readI2CRegister16bitUnsigned(sensorAddress, SOILMOISTURESENSOR_GET_LIGHT);
 }
@@ -207,7 +210,7 @@ uint16_t I2CSoilMoistureSensor::readI2CRegister16bitUnsigned(int addr, byte reg)
   i2cBeginTransmission((uint8_t)addr);
   i2cWrite((uint8_t)reg);
   i2cEndTransmission();
-  delay(readslow);
+  delay(readSlowDelay);
   i2cRequestFrom((uint8_t)addr, (byte)2);
   value = (i2cRead() << 8) | i2cRead();
 
@@ -229,7 +232,7 @@ uint8_t I2CSoilMoistureSensor::readI2CRegister8bit(int addr, int reg) {
   i2cBeginTransmission(addr);
   i2cWrite(reg);
   i2cEndTransmission();
-  delay(readslow);
+  delay(readSlowDelay);
   i2cRequestFrom(addr, 1);
   return i2cRead();
 }

--- a/I2CSoilMoistureSensor.cpp
+++ b/I2CSoilMoistureSensor.cpp
@@ -38,6 +38,7 @@
 #define i2cWrite Wire.send
 #endif
 
+int readslow = 20
 /*----------------------------------------------------------------------*
  * Constructor.                                                         *
  * Optionally set sensor I2C address if different from default          *
@@ -54,10 +55,13 @@ I2CSoilMoistureSensor::I2CSoilMoistureSensor(uint8_t addr) : sensorAddress(addr)
  * Alternatively use true as parameter and the method waits for a       *
  * second and returns after that.                                       *
  *----------------------------------------------------------------------*/
-void I2CSoilMoistureSensor::begin(bool wait) {
+void I2CSoilMoistureSensor::begin(bool wait, bool readslowbool) {
   resetSensor();
   if (wait) {
     delay(1000);
+  }
+  if (readslowbool) {
+    readslow = 1100;
   }
 }
 
@@ -203,7 +207,7 @@ uint16_t I2CSoilMoistureSensor::readI2CRegister16bitUnsigned(int addr, byte reg)
   i2cBeginTransmission((uint8_t)addr);
   i2cWrite((uint8_t)reg);
   i2cEndTransmission();
-  delay(20);
+  delay(readslow);
   i2cRequestFrom((uint8_t)addr, (byte)2);
   value = (i2cRead() << 8) | i2cRead();
 
@@ -225,7 +229,7 @@ uint8_t I2CSoilMoistureSensor::readI2CRegister8bit(int addr, int reg) {
   i2cBeginTransmission(addr);
   i2cWrite(reg);
   i2cEndTransmission();
-  delay(20);
+  delay(readslow);
   i2cRequestFrom(addr, 1);
   return i2cRead();
 }

--- a/I2CSoilMoistureSensor.h
+++ b/I2CSoilMoistureSensor.h
@@ -7,15 +7,15 @@
  * https://github.com/Apollon77/I2CSoilMoistureSensor                   *
  *                                                                      *
  * MIT license                                                          *
- *----------------------------------------------------------------------*/ 
+ *----------------------------------------------------------------------*/
 
 #ifndef I2CSOILMOISTURESENSOR_H
 #define I2CSOILMOISTURESENSOR_H
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include <Arduino.h> 
+#include <Arduino.h>
 #else
-#include <WProgram.h> 
+#include <WProgram.h>
 #endif
 
 //Default I2C Address of the sensor
@@ -38,7 +38,7 @@ class I2CSoilMoistureSensor {
     public:
         I2CSoilMoistureSensor(uint8_t addr = SOILMOISTURESENSOR_DEFAULT_ADDR);
 
-		void begin(bool wait = false);
+		void begin(bool wait = false, bool readslowbool = false);
         unsigned int getCapacitance();
         bool setAddress(int addr, bool reset);
         void changeSensor(int addr, bool wait = false);

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ For ESP8266 it seems to be necessary to use ***Wire.setClockStretchLimit(2500);*
 Optionally set sensor I2C address if different from default
 
 
-### begin(bool wait)
+### begin(bool wait, bool readSlowOption)
 Initializes anything ... it does a reset.
-When used without parameter or parameter value is false then a
+Parameter One, when used without parameter or parameter value is false then a
 waiting time of at least 1 second is expected to give the sensor
-some time to boot up.
-Alternatively use true as parameter and the method waits for a
+some time to boot up. Alternatively use true as parameter and the method waits for a
 second and returns after that.
+The second parameter is optional, when set to true tells the I2C reads to run slower as required to work with the "full" chirp version,    can be set to faluse to work with the "sensor mode only" version (without the chirp function).
 
 ### getCapacitance()
 Return measured Soil Moisture Capacitance Moisture is somewhat linear. More moisture will

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # I2CSoilMoistureSensor
 
-Simple Arduino Library for both the standalone I2C Soil Moisture Sensor and "full" 'Chirp! - plant watering alarm' version from Chirp
+Simple Arduino Library for both the standalone I2C Soil Moisture Sensor and "full" 'Chirp! - plant watering alarm' version from 
 (https://github.com/Miceuz/i2c-moisture-sensor and https://github.com/Miceuz/PlantWateringAlarm) which works really great and is ready to
 use with I2C.
 
@@ -85,7 +85,8 @@ reading. Be aware, light sensor is pretty noisy.
 ### getTemperature()
 Read the Temperature Measurement. Temperature is measured by the thermistor on the tip of
 the sensor. Calculated absolute measurement accuracy is better than 2%. The returned value
-is in degrees Celsius with factor 10, so need to divide by 10 to get real value
+is in degrees Celsius with factor 10, so need to divide by 10 to get real value.
+Note: The 'Chirp! - plant watering alarm' version is without a thermistor, so cannot report the temperature.
 
 ### sleep()
 Powers down the sensor. Use this function in order to save power inbetween measurements.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ Simple Arduino Library for both the standalone I2C Soil Moisture Sensor and "ful
 use with I2C.
 
 ## Information
-More information at: https://www.tindie.com/products/miceuz/i2c-soil-moisture-sensor/ and https://www.tindie.com/products/miceuz/chirp-plant-watering-alarm/
+More information at: 
+- https://www.tindie.com/products/miceuz/i2c-soil-moisture-sensor/
+- https://www.tindie.com/products/miceuz/chirp-plant-watering-alarm/
+- https://wemakethings.net/chirp/
 
 ## Version History
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # I2CSoilMoistureSensor
 
-Simple Arduino Library for both the standalone I2C Soil Moisture Sensor and "full" version from Chirp
+Simple Arduino Library for both the standalone I2C Soil Moisture Sensor and "full" 'Chirp! - plant watering alarm' version from Chirp
 (https://github.com/Miceuz/i2c-moisture-sensor and https://github.com/Miceuz/PlantWateringAlarm) which works really great and is ready to
 use with I2C.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # I2CSoilMoistureSensor
 
-Simple Arduino Library for the I2C Soil Moisture Sensor version from Chirp
-(https://github.com/Miceuz/i2c-moisture-sensor) which works really great and is ready to
+Simple Arduino Library for both the standalone I2C Soil Moisture Sensor and "full" version from Chirp
+(https://github.com/Miceuz/i2c-moisture-sensor and https://github.com/Miceuz/PlantWateringAlarm) which works really great and is ready to
 use with I2C.
 
 ## Information
-More information at: https://www.tindie.com/products/miceuz/i2c-soil-moisture-sensor/
+More information at: https://www.tindie.com/products/miceuz/i2c-soil-moisture-sensor/ and https://www.tindie.com/products/miceuz/chirp-plant-watering-alarm/
 
 ## Version History
+
+### vx.x.x
+- Added options to work with the "full" version from Chirp.
 
 ### v1.1.4
 -  updated the change address protocol to be compatible with firmware version 2.6 and later.
@@ -34,11 +37,11 @@ Optionally set sensor I2C address if different from default
 
 ### begin(bool wait, bool readSlowOption)
 Initializes anything ... it does a reset.
-Parameter One, when used without parameter or parameter value is false then a
+First parameter when used without parameter or parameter value is false then a
 waiting time of at least 1 second is expected to give the sensor
 some time to boot up. Alternatively use true as parameter and the method waits for a
 second and returns after that.
-The second parameter is optional, when set to true tells the I2C reads to run slower as required to work with the "full" chirp version,    can be set to faluse to work with the "sensor mode only" version (without the chirp function).
+The second parameter is optional, when set true tells the I2C reads to run slower as required to work with the "full" chirp version,    can be set to false to work with the standalone "sensor mode only" version (without the chirp function).
 
 ### getCapacitance()
 Return measured Soil Moisture Capacitance Moisture is somewhat linear. More moisture will


### PR DESCRIPTION
Added and tested option to library to use different delays in the two I2CSoilMoistureSensor functions, depending if you are using the I2C or "full" chirp sensor.

